### PR TITLE
Made fields with explicit accessors private

### DIFF
--- a/contracts/Raphael.sol
+++ b/contracts/Raphael.sol
@@ -34,8 +34,8 @@ contract Raphael is ERC721Holder, Ownable, ReentrancyGuard {
     mapping(uint256 => mapping(address => bool)) private voted; //global voted mapping
 
     uint256 public proposalCount;
-    uint256 public minVotesNeeded;
 
+    uint256 private minVotesNeeded;
     address private nativeTokenAddress;
     address private stakingContractAddress;
     address[] private nftContractAddresses;

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -9,8 +9,8 @@ contract Staking is IStaking, ReentrancyGuard {
     mapping(address => uint256) private _stakedBalances;
     mapping(address => uint256) private _unlockTimes;
 
-    address public tokenAddress;
-    address public daoAddress;
+    address private tokenAddress;
+    address private daoAddress;
     uint256 totalStakedBalance;
     bool shutdown=false;
 


### PR DESCRIPTION
Two fields, tokenAddress and daoAddress have explicit getters, so having them public is redundant. Simply made them private.